### PR TITLE
Fix: add babel-cli to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ejs-html-loader",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Webpack loader for rendering HTML from EJS templates",
   "main": "lib/index.js",
   "scripts": {
@@ -42,6 +42,7 @@
     "loader-utils": "^0.2.15"
   },
   "devDependencies": {
+    "babel-cli": "^6.9.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",


### PR DESCRIPTION
Build failed without `babel-cli` installed. This fixes that.
