### PR TITLE
Fix: recursive includes

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -1,14 +1,30 @@
+import {readFileSync} from 'fs';
 import {compile} from 'ejs';
 
 export function render(ctx, src, data) {
-  let template = compile(src, {
-    filename: ctx.resourcePath,
-    delimiter: data.delimiter,
-    context: data.context
-  });
+  let filename = ctx.resourcePath;
+  let delimiter = data.delimiter;
+  let context = data.context;
+
+  let tpl = compile(src, {filename, delimiter, context});
 
   return {
-    rendered: template(data),
-    deps: template.dependencies
+    rendered: tpl(data),
+    deps: getDeps(tpl.dependencies, {delimiter, context})
   };
+}
+
+function getDeps(deps, opts, result=[]) {
+  deps.forEach(name => {
+    result.push(name);
+    getDeps(getOwnDeps(name, opts), opts, result);
+  });
+
+  return result;
+}
+
+function getOwnDeps(filename, {delimiter, context}) {
+  let src = readFileSync(filename, 'utf8');
+  let tpl = compile(src, {filename, delimiter, context});
+  return tpl.dependencies;
 }


### PR DESCRIPTION
Fixes #4

Previously, only included statements in the top-level EJS file were
added as dependencies. This commit adds support for recursive
dependencies.
